### PR TITLE
Improve GR00T-N1.7 inference latency to PyTorch-eager parity

### DIFF
--- a/patches/llama.cpp-vla.patch
+++ b/patches/llama.cpp-vla.patch
@@ -35,6 +35,107 @@ index 7f4a4018f..6be188287 100755
  class ConformerAudioModel(MmprojModel):
      _batch_norm_tensors: list[dict[str, Tensor]] | None = None
  
+diff --git a/ggml/src/ggml-cuda/fattn-tile.cu b/ggml/src/ggml-cuda/fattn-tile.cu
+index d60634cc0..83bcd3f8c 100644
+--- a/ggml/src/ggml-cuda/fattn-tile.cu
++++ b/ggml/src/ggml-cuda/fattn-tile.cu
+@@ -10,6 +10,10 @@ void ggml_cuda_flash_attn_ext_tile(ggml_backend_cuda_context & ctx, ggml_tensor
+             GGML_ASSERT(V->ne[0] == K->ne[0]);
+             ggml_cuda_flash_attn_ext_tile_case< 40,  40>(ctx, dst);
+         } break;
++        case  48: {
++            GGML_ASSERT(V->ne[0] == K->ne[0]);
++            ggml_cuda_flash_attn_ext_tile_case< 48,  48>(ctx, dst);
++        } break;
+         case  64: {
+             GGML_ASSERT(V->ne[0] == K->ne[0]);
+             ggml_cuda_flash_attn_ext_tile_case< 64,  64>(ctx, dst);
+diff --git a/ggml/src/ggml-cuda/fattn-tile.cuh b/ggml/src/ggml-cuda/fattn-tile.cuh
+index 585f2c228..afbc26f13 100644
+--- a/ggml/src/ggml-cuda/fattn-tile.cuh
++++ b/ggml/src/ggml-cuda/fattn-tile.cuh
+@@ -26,6 +26,12 @@ static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_nv
+     GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 16, 256, 2,  64,  40)
+     GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 32, 256, 2,  64,  40)
+ 
++    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 48,  48,  2,  64, 2,  64,  48)
++    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 48,  48,  4, 128, 2,  64,  48)
++    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 48,  48,  8, 256, 2,  64,  48)
++    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 48,  48, 16, 256, 2,  64,  48)
++    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 48,  48, 32, 256, 2,  64,  48)
++
+     GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  2,  64, 2,  64,  64)
+     GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  4, 128, 2,  64,  64)
+     GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  8, 256, 2,  64,  64)
+@@ -88,6 +94,12 @@ static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_nv
+     GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 16, 256, 2,  32,  40)
+     GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 32, 256, 2,  32,  40)
+ 
++    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 48,  48,  2,  64, 2,  32,  48)
++    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 48,  48,  4, 128, 2,  32,  48)
++    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 48,  48,  8, 256, 2,  32,  48)
++    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 48,  48, 16, 256, 2,  32,  48)
++    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 48,  48, 32, 256, 2,  32,  48)
++
+     GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  2, 128, 3,  64,  64)
+     GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  4, 128, 3,  32,  64)
+     GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  8, 128, 3,  32,  64)
+diff --git a/ggml/src/ggml-cuda/fattn.cu b/ggml/src/ggml-cuda/fattn.cu
+index 8256591b2..dca4f0b8d 100644
+--- a/ggml/src/ggml-cuda/fattn.cu
++++ b/ggml/src/ggml-cuda/fattn.cu
+@@ -357,6 +357,7 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
+ 
+     switch (K->ne[0]) {
+         case  40:
++        case  48:
+         case  64:
+         case  72:
+         case  80:
+@@ -428,7 +429,7 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
+     const bool can_use_vector_kernel = Q->ne[0] <= 256 && Q->ne[0] % 64 == 0 && K->ne[1] % FATTN_KQ_STRIDE == 0;
+ 
+     // If Turing tensor cores are available, use them:
+-    if (turing_mma_available(cc) && Q->ne[0] != 40 && Q->ne[0] != 72) {
++    if (turing_mma_available(cc) && Q->ne[0] != 40 && Q->ne[0] != 48 && Q->ne[0] != 72) {
+         if (can_use_vector_kernel) {
+             if (!ggml_is_quantized(K->type) && !ggml_is_quantized(V->type)) {
+                 if (cc >= GGML_CUDA_CC_ADA_LOVELACE && Q->ne[1] == 1 && Q->ne[3] == 1 && !(gqa_ratio > 4 && K->ne[1] >= 8192)) {
+@@ -452,7 +453,7 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
+         return BEST_FATTN_KERNEL_MMA_F16;
+     }
+ 
+-    if (volta_mma_available(cc) && Q->ne[0] != 40 && Q->ne[0] != 72) {
++    if (volta_mma_available(cc) && Q->ne[0] != 40 && Q->ne[0] != 48 && Q->ne[0] != 72) {
+         int gqa_ratio_eff = 1;
+         const int ncols2_max = Q->ne[0] == 576 ? 16 : 8;
+         while (gqa_ratio % (2*gqa_ratio_eff) == 0 && gqa_ratio_eff < ncols2_max) {
+@@ -468,14 +469,14 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
+     }
+ 
+     // Use the WMMA kernel if possible:
+-    if (ggml_cuda_should_use_wmma_fattn(cc) && K->ne[1] % FATTN_KQ_STRIDE == 0 && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[0] != 512 && Q->ne[0] != 576) {
++    if (ggml_cuda_should_use_wmma_fattn(cc) && K->ne[1] % FATTN_KQ_STRIDE == 0 && Q->ne[0] != 40 && Q->ne[0] != 48 && Q->ne[0] != 72 && Q->ne[0] != 512 && Q->ne[0] != 576) {
+         if (can_use_vector_kernel && Q->ne[1] <= 2) {
+             return BEST_FATTN_KERNEL_VEC;
+         }
+         return BEST_FATTN_KERNEL_WMMA_F16;
+     }
+ 
+-    if (amd_wmma_available(cc) && GGML_CUDA_CC_IS_RDNA4(cc) && gqa_opt_applies && Q->ne[0] <= 128 && Q->ne[0] != 40 && Q->ne[0] != 72) {
++    if (amd_wmma_available(cc) && GGML_CUDA_CC_IS_RDNA4(cc) && gqa_opt_applies && Q->ne[0] <= 128 && Q->ne[0] != 40 && Q->ne[0] != 48 && Q->ne[0] != 72) {
+         if (can_use_vector_kernel) {
+             if (!ggml_is_quantized(K->type) && !ggml_is_quantized(V->type)) {
+                 if (Q->ne[1] == 1) {
+@@ -501,7 +502,7 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
+     }
+ 
+     // Use MFMA flash attention for CDNA (MI100+):
+-    if (amd_mfma_available(cc) && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[0] != 256 && Q->ne[0] != 512 && Q->ne[0] != 576) {
++    if (amd_mfma_available(cc) && Q->ne[0] != 40 && Q->ne[0] != 48 && Q->ne[0] != 72 && Q->ne[0] != 256 && Q->ne[0] != 512 && Q->ne[0] != 576) {
+         const int64_t eff_nq = Q->ne[1] * (gqa_opt_applies ? gqa_ratio : 1);
+         // MMA vs tile crossover benchmarked on MI300X @ d32768:
+         //   hsk=64  (gqa=4): MMA wins at eff >= 128 (+11%)
 diff --git a/gguf-py/gguf/constants.py b/gguf-py/gguf/constants.py
 index 83ae51ce9..85209b51a 100644
 --- a/gguf-py/gguf/constants.py

--- a/patches/patch.sh
+++ b/patches/patch.sh
@@ -32,7 +32,7 @@ LLAMA_DIR="$ROOT/third_party/llama.cpp"
 LLAMA_URL="https://github.com/ggml-org/llama.cpp.git"
 LLAMA_TAG="b9016"
 PATCH="$ROOT/patches/llama.cpp-vla.patch"
-PATCH_SHA256_EXPECTED="6210a07bc756ed560e692d5c8c42c4136e715274359fa67826e4722655931758"
+PATCH_SHA256_EXPECTED="6fc133c323caf30f9213d774fb8941f95b504a5a34c7c25397bfa03ef4817c67"
 
 [[ -f "$PATCH" ]] || { echo "patch not found: $PATCH" >&2; exit 1; }
 

--- a/src/models/gr00tn1d7.cpp
+++ b/src/models/gr00tn1d7.cpp
@@ -32,6 +32,7 @@
 #include <limits>
 #include <memory>
 #include <random>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -126,7 +127,8 @@ struct VitLayerW   { ggml_tensor *ln1w,*ln1b,*ln2w,*ln2b,*Wqkv,*bqkv,*Wo,*bo,*Wf
 struct MergerW     { ggml_tensor *nw,*nb,*fc1w,*fc1b,*fc2w,*fc2b; };
 struct VlsaLayerW  { ggml_tensor *n1w,*n1b,*n3w,*n3b,*Wq,*bq,*Wk,*bk,*Wv,*bv,*Wo,*bo,*Wff0,*bff0,*Wff2,*bff2; };
 struct Qwen3LayerW { ggml_tensor *attn_norm,*Wq,*Wk,*Wv,*Wo,*q_norm,*k_norm,*ffn_norm,*Wgate,*Wup,*Wdown; };
-struct DitLayerW   { ggml_tensor *adaln_w,*adaln_b,*Wq,*bq,*Wk,*bk,*Wv,*bv,*Wo,*bo,*Wff0,*bff0,*Wff2,*bff2; };
+struct DitLayerW   { ggml_tensor *adaln_w,*adaln_b,*Wq,*bq,*Wk,*bk,*Wv,*bv,*Wo,*bo,*Wff0,*bff0,*Wff2,*bff2;
+                     ggml_tensor *Wqkv=nullptr,*bqkv=nullptr,*Wkv=nullptr,*bkv=nullptr; };
 
 }
 
@@ -171,6 +173,26 @@ struct Gr00tN1d7ModelArch : public ModelArchBase {
     std::vector<DitLayerW> dit;
     ggml_tensor *po1W=nullptr,*po1b=nullptr,*po2W=nullptr,*po2b=nullptr;
 
+    bool                            caches_ready = false;
+    std::vector<int64_t>            c_grow, c_gcol;
+    std::vector<float>              c_rope_cos, c_rope_sin;
+    std::vector<float>              c_pos_interp;
+    std::vector<std::vector<float>> c_tau, c_tproj;
+    std::vector<float>              c_mask; int64_t c_mask_seq = -1;
+    gguf_reader                     io;
+    bool build_caches();
+
+    struct MainGraph {
+        ggml_context * C = nullptr; ggml_gallocr_t galloc = nullptr; ggml_cgraph * gf = nullptr;
+        ggml_tensor *t_embeds=nullptr,*t_pos=nullptr,*t_lmmask=nullptr,*t_state=nullptr,*t_x0=nullptr;
+        ggml_tensor *t_ds[3]={nullptr,nullptr,nullptr};
+        ggml_tensor *t_img_idx=nullptr,*t_txt_idx=nullptr,*actions=nullptr;
+        std::vector<ggml_tensor*> t_tau, t_tproj;
+        int64_t seq=-1,n_img=-1,seq_txt=-1,nsteps=-1; bool deepstack=false; bool valid=false;
+        void release() { if (galloc) ggml_gallocr_free(galloc); if (C) ggml_free(C);
+                         galloc=nullptr; C=nullptr; gf=nullptr; valid=false; t_tau.clear(); t_tproj.clear(); }
+    } mg;
+
     std::vector<float> predict(const Inputs& in) override;
 };
 
@@ -198,6 +220,23 @@ ggml_tensor * rope2d(ggml_context * C, ggml_tensor * x, ggml_tensor * cos_t, ggm
     return ggml_add(C, ggml_mul(C, x, cos_t), ggml_mul(C, rot, sin_t));
 }
 
+inline bool fa_enabled() { static const bool e = (std::getenv("VLA_GR00T_FA") != nullptr); return e; }
+
+ggml_tensor * head_view(ggml_context * C, ggml_tensor * proj, int64_t hd, int64_t heads,
+                        int64_t T, int64_t E, int nblk, int blk) {
+    const size_t es = ggml_element_size(proj);
+    return ggml_view_3d(C, proj, hd, heads, T, (size_t) hd * es, (size_t) nblk * E * es, (size_t) blk * E * es);
+}
+
+ggml_tensor * flash_attn(ggml_context * C, ggml_tensor * q, ggml_tensor * k, ggml_tensor * v,
+                         ggml_tensor * mask, float scale, int64_t hidden) {
+    ggml_tensor * kf = (k->type == GGML_TYPE_F16) ? k : ggml_cast(C, k, GGML_TYPE_F16);
+    ggml_tensor * vf = (v->type == GGML_TYPE_F16) ? v : ggml_cast(C, v, GGML_TYPE_F16);
+    ggml_tensor * o  = ggml_flash_attn_ext(C, q, kf, vf, mask, scale, 0.0f, 0.0f);
+    ggml_flash_attn_ext_set_prec(o, GGML_PREC_F32);
+    return ggml_reshape_2d(C, o, o->ne[0] * o->ne[1], o->ne[2] * o->ne[3]);
+}
+
 ggml_tensor * build_vit_layer(ggml_context * C, const VitLayerW & w, ggml_tensor * x, ggml_tensor * cos_t, ggml_tensor * sin_t,
                               int64_t seq, int64_t heads, int64_t hd, int64_t hidden, float ln_eps) {
     const float scale = 1.0f / std::sqrt((float) hd);
@@ -209,10 +248,16 @@ ggml_tensor * build_vit_layer(ggml_context * C, const VitLayerW & w, ggml_tensor
     ggml_tensor * Q = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, q, hd, heads, seq), 0, 2, 1, 3));
     ggml_tensor * K = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, k, hd, heads, seq), 0, 2, 1, 3));
     Q = rope2d(C, Q, cos_t, sin_t); K = rope2d(C, K, cos_t, sin_t);
-    ggml_tensor * V = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, v, hd, heads, seq), 1, 2, 0, 3));
-    ggml_tensor * kq = ggml_mul_mat(C, K, Q); ggml_mul_mat_set_prec(kq, GGML_PREC_F32);
-    ggml_tensor * aw = ggml_soft_max_ext(C, kq, nullptr, scale, 0.0f);
-    ggml_tensor * att = ggml_reshape_2d(C, ggml_cont(C, ggml_permute(C, ggml_mul_mat(C, V, aw), 0, 2, 1, 3)), hidden, seq);
+    ggml_tensor * att;
+    if (fa_enabled()) {
+        ggml_tensor * V = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, v, hd, heads, seq), 0, 2, 1, 3));
+        att = flash_attn(C, Q, K, V, nullptr, scale, hidden);
+    } else {
+        ggml_tensor * V = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, v, hd, heads, seq), 1, 2, 0, 3));
+        ggml_tensor * kq = ggml_mul_mat(C, K, Q); ggml_mul_mat_set_prec(kq, GGML_PREC_F32);
+        ggml_tensor * aw = ggml_soft_max_ext(C, kq, nullptr, scale, 0.0f);
+        att = ggml_reshape_2d(C, ggml_cont(C, ggml_permute(C, ggml_mul_mat(C, V, aw), 0, 2, 1, 3)), hidden, seq);
+    }
     ggml_tensor * h1 = ggml_add(C, x, ggml_add(C, ggml_mul_mat(C, w.Wo, att), w.bo));
     ggml_tensor * n2 = ggml_add(C, ggml_mul(C, ggml_norm(C, h1, ln_eps), w.ln2w), w.ln2b);
     ggml_tensor * ff = ggml_add(C, ggml_mul_mat(C, w.Wfc2, ggml_gelu(C, ggml_add(C, ggml_mul_mat(C, w.Wfc1, n2), w.bfc1))), w.bfc2);
@@ -243,10 +288,16 @@ ggml_tensor * build_vlsa_layer(ggml_context * C, const VlsaLayerW & w, ggml_tens
     ggml_tensor * v = ggml_add(C, ggml_mul_mat(C, w.Wv, n1), w.bv);
     ggml_tensor * Q = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, q, hd, heads, seq), 0, 2, 1, 3));
     ggml_tensor * K = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, k, hd, heads, seq), 0, 2, 1, 3));
-    ggml_tensor * V = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, v, hd, heads, seq), 1, 2, 0, 3));
-    ggml_tensor * kq = ggml_mul_mat(C, K, Q); ggml_mul_mat_set_prec(kq, GGML_PREC_F32);
-    ggml_tensor * aw = ggml_soft_max_ext(C, kq, nullptr, scale, 0.0f);
-    ggml_tensor * att = ggml_reshape_2d(C, ggml_cont(C, ggml_permute(C, ggml_mul_mat(C, V, aw), 0, 2, 1, 3)), hidden, seq);
+    ggml_tensor * att;
+    if (fa_enabled()) {
+        ggml_tensor * V = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, v, hd, heads, seq), 0, 2, 1, 3));
+        att = flash_attn(C, Q, K, V, nullptr, scale, hidden);
+    } else {
+        ggml_tensor * V = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, v, hd, heads, seq), 1, 2, 0, 3));
+        ggml_tensor * kq = ggml_mul_mat(C, K, Q); ggml_mul_mat_set_prec(kq, GGML_PREC_F32);
+        ggml_tensor * aw = ggml_soft_max_ext(C, kq, nullptr, scale, 0.0f);
+        att = ggml_reshape_2d(C, ggml_cont(C, ggml_permute(C, ggml_mul_mat(C, V, aw), 0, 2, 1, 3)), hidden, seq);
+    }
     ggml_tensor * h1 = ggml_add(C, x, ggml_add(C, ggml_mul_mat(C, w.Wo, att), w.bo));
     ggml_tensor * n3 = ggml_add(C, ggml_mul(C, ggml_norm(C, h1, ln_eps), w.n3w), w.n3b);
     ggml_tensor * ff = ggml_add(C, ggml_mul_mat(C, w.Wff2, ggml_gelu(C, ggml_add(C, ggml_mul_mat(C, w.Wff0, n3), w.bff0))), w.bff2);
@@ -271,10 +322,16 @@ ggml_tensor * build_qwen3_layer(ggml_context * C, const Gr00tN1d7ModelArch & m, 
     ggml_tensor * kr = ggml_rope_multi(C, kn, positions, nullptr, (int) hd, sections, GGML_ROPE_TYPE_IMROPE, 0, m.lm_rope_base, 1.0f, 0.0f, 1.0f, 32.0f, 1.0f);
     ggml_tensor * Q = ggml_cont(C, ggml_permute(C, qr, 0, 2, 1, 3));
     ggml_tensor * K = ggml_cont(C, ggml_permute(C, kr, 0, 2, 1, 3));
-    ggml_tensor * V = ggml_cont(C, ggml_permute(C, vh, 1, 2, 0, 3));
-    ggml_tensor * kq = ggml_mul_mat(C, K, Q); ggml_mul_mat_set_prec(kq, GGML_PREC_F32);
-    ggml_tensor * aw = ggml_soft_max_ext(C, kq, mask, scale, 0.0f);
-    ggml_tensor * att = ggml_reshape_2d(C, ggml_cont(C, ggml_permute(C, ggml_mul_mat(C, V, aw), 0, 2, 1, 3)), hq, seq);
+    ggml_tensor * att;
+    if (fa_enabled()) {
+        ggml_tensor * V = ggml_cont(C, ggml_permute(C, vh, 0, 2, 1, 3));
+        att = flash_attn(C, Q, K, V, ggml_cast(C, mask, GGML_TYPE_F16), scale, hq);
+    } else {
+        ggml_tensor * V = ggml_cont(C, ggml_permute(C, vh, 1, 2, 0, 3));
+        ggml_tensor * kq = ggml_mul_mat(C, K, Q); ggml_mul_mat_set_prec(kq, GGML_PREC_F32);
+        ggml_tensor * aw = ggml_soft_max_ext(C, kq, mask, scale, 0.0f);
+        att = ggml_reshape_2d(C, ggml_cont(C, ggml_permute(C, ggml_mul_mat(C, V, aw), 0, 2, 1, 3)), hq, seq);
+    }
     ggml_tensor * h_attn = ggml_add(C, h, ggml_mul_mat(C, w.Wo, att));
     ggml_tensor * hn2 = ggml_mul(C, ggml_rms_norm(C, h_attn, m.lm_rms_eps), w.ffn_norm);
     ggml_tensor * gate = ggml_silu(C, ggml_mul_mat(C, w.Wgate, hn2));
@@ -282,19 +339,39 @@ ggml_tensor * build_qwen3_layer(ggml_context * C, const Gr00tN1d7ModelArch & m, 
     return ggml_add(C, h_attn, ggml_mul_mat(C, w.Wdown, ggml_mul(C, gate, up)));
 }
 
+void dit_kv(ggml_context * C, const Gr00tN1d7ModelArch & m, const DitLayerW & w, ggml_tensor * kv,
+            ggml_tensor ** K_out, ggml_tensor ** V_out) {
+    const int64_t hd = m.dit_head_dim, heads = m.dit_heads, dim = m.dit_hidden, Tkv = kv->ne[1];
+    if (w.Wkv) {
+        ggml_tensor * kvp = ggml_add(C, ggml_mul_mat(C, w.Wkv, kv), w.bkv);
+        *K_out = ggml_cont(C, ggml_permute(C, head_view(C, kvp, hd, heads, Tkv, dim, 2, 0), 0, 2, 1, 3));
+        *V_out = ggml_cont(C, ggml_permute(C, head_view(C, kvp, hd, heads, Tkv, dim, 2, 1), 1, 2, 0, 3));
+        return;
+    }
+    ggml_tensor * k = ggml_add(C, ggml_mul_mat(C, w.Wk, kv), w.bk);
+    ggml_tensor * v = ggml_add(C, ggml_mul_mat(C, w.Wv, kv), w.bv);
+    *K_out = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, k, hd, heads, Tkv), 0, 2, 1, 3));
+    *V_out = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, v, hd, heads, Tkv), 1, 2, 0, 3));
+}
+
 ggml_tensor * build_dit_block(ggml_context * C, const Gr00tN1d7ModelArch & m, const DitLayerW & w,
-                              ggml_tensor * h, ggml_tensor * temb, ggml_tensor * enc ) {
+                              ggml_tensor * h, ggml_tensor * temb, ggml_tensor * enc ,
+                              ggml_tensor * K_pre = nullptr, ggml_tensor * V_pre = nullptr) {
     const int64_t hd = m.dit_head_dim, heads = m.dit_heads, dim = m.dit_hidden, Tk = h->ne[1];
     const float scale = 1.0f / std::sqrt((float) hd);
     ggml_tensor * n = adaln(C, h, temb, w.adaln_w, w.adaln_b, dim, m.ln_eps);
-    ggml_tensor * kv = enc ? enc : n;
-    const int64_t Tkv = kv->ne[1];
-    ggml_tensor * q = ggml_add(C, ggml_mul_mat(C, w.Wq, n),  w.bq);
-    ggml_tensor * k = ggml_add(C, ggml_mul_mat(C, w.Wk, kv), w.bk);
-    ggml_tensor * v = ggml_add(C, ggml_mul_mat(C, w.Wv, kv), w.bv);
-    ggml_tensor * Q = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, q, hd, heads, Tk),  0, 2, 1, 3));
-    ggml_tensor * K = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, k, hd, heads, Tkv), 0, 2, 1, 3));
-    ggml_tensor * V = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, v, hd, heads, Tkv), 1, 2, 0, 3));
+    ggml_tensor * K, * V, * Q;
+    if (!enc && w.Wqkv) {
+        ggml_tensor * qkv = ggml_add(C, ggml_mul_mat(C, w.Wqkv, n), w.bqkv);
+        Q = ggml_cont(C, ggml_permute(C, head_view(C, qkv, hd, heads, Tk, dim, 3, 0), 0, 2, 1, 3));
+        K = ggml_cont(C, ggml_permute(C, head_view(C, qkv, hd, heads, Tk, dim, 3, 1), 0, 2, 1, 3));
+        V = ggml_cont(C, ggml_permute(C, head_view(C, qkv, hd, heads, Tk, dim, 3, 2), 1, 2, 0, 3));
+    } else {
+        ggml_tensor * q = ggml_add(C, ggml_mul_mat(C, w.Wq, n),  w.bq);
+        Q = ggml_cont(C, ggml_permute(C, ggml_reshape_3d(C, q, hd, heads, Tk),  0, 2, 1, 3));
+        if (K_pre) { K = K_pre; V = V_pre; }
+        else       { dit_kv(C, m, w, enc ? enc : n, &K, &V); }
+    }
     ggml_tensor * kq = ggml_mul_mat(C, K, Q); ggml_mul_mat_set_prec(kq, GGML_PREC_F32);
     ggml_tensor * aw = ggml_soft_max_ext(C, kq, nullptr, scale, 0.0f);
     ggml_tensor * att = ggml_reshape_2d(C, ggml_cont(C, ggml_permute(C, ggml_mul_mat(C, V, aw), 0, 2, 1, 3)), dim, Tk);
@@ -395,6 +472,11 @@ bool load_config(const gguf_reader & g, Gr00tN1d7ModelArch & m, Config & cfg) {
     U(fk("action_horizon"), m.action_horizon); U(fk("action_dim"), m.action_dim); U(fk("max_state_dim"), m.max_state_dim);
     U(fk("num_inference_timesteps"), m.num_steps); U(fk("num_timestep_buckets"), m.num_buckets); U(fk("max_num_embodiments"), m.max_embodiments); U(fk("max_seq_len"), m.max_seq_len);
     U(fk("image_target_size"), m.image_target_size);
+
+    if (const char * ns = std::getenv("VLA_NUM_STEPS")) {
+        char * end = nullptr; long v = std::strtol(ns, &end, 10);
+        if (end && *end == '\0' && v >= 1) { m.num_steps = (int64_t) v; std::fprintf(stderr, "vla(gr00tn1d7): VLA_NUM_STEPS override → num_steps=%lld\n", (long long) v); }
+    }
     F(fk("vit_ln_eps"), m.vit_ln_eps); F(fk("lm_rms_eps"), m.lm_rms_eps); F(fk("ln_eps"), m.ln_eps); F(fk("norm_out_eps"), m.norm_out_eps);
     F(fk("vlln_eps"), m.vlln_eps); F(fk("vlsa_ln_eps"), m.vlsa_ln_eps); F(fk("connector_ln_eps"), m.connector_ln_eps); F(fk("vit_rope_theta"), m.vit_rope_base);
     if (g.has(fk("lm_rope_theta"))) m.lm_rope_base = (float) g.f64(fk("lm_rope_theta"));
@@ -431,6 +513,7 @@ bool load_config(const gguf_reader & g, Gr00tN1d7ModelArch & m, Config & cfg) {
 }
 
 Gr00tN1d7ModelArch::~Gr00tN1d7ModelArch() {
+    mg.release();
     if (weight_buf)  ggml_backend_buffer_free(weight_buf);
     if (ctx_weights) ggml_free(ctx_weights);
     if (backend)     ggml_backend_free(backend);
@@ -440,7 +523,7 @@ std::unique_ptr<ModelArchBase> gr00t_n1_7_create(const std::string& mmproj_path,
                                                  const std::string& ckpt_path,
                                                  const std::string& ) {
     if (!mmproj_path.empty())
-        std::printf("vla(gr00tn1d7): note - mmproj '%s' is ignored (the vision tower is bundled in the combined GGUF)\n", mmproj_path.c_str());
+        std::printf("vla(gr00tn1d7): note — mmproj '%s' is ignored (the vision tower is bundled in the combined GGUF)\n", mmproj_path.c_str());
 
     auto m = std::make_unique<Gr00tN1d7ModelArch>();
     m->gguf_path   = ckpt_path;
@@ -485,6 +568,21 @@ std::unique_ptr<ModelArchBase> gr00t_n1_7_create(const std::string& mmproj_path,
     };
     auto mk_mm  = [&](const char * name) { return mk(name, m->matmul_type); };
     auto mk_f32 = [&](const char * name) { return mk(name, GGML_TYPE_F32); };
+
+    struct FusedSpec { ggml_tensor * dst; std::vector<std::string> srcs; };
+    std::vector<FusedSpec> fused;
+    const bool fuse = true;
+    auto mk_fused = [&](const char * out_name, std::vector<const char *> srcs, ggml_type type) -> ggml_tensor * {
+        const ggml_tensor * g0 = g.meta(srcs[0]);
+        if (!g0) { std::fprintf(stderr, "vla(gr00tn1d7): fused src missing %s\n", srcs[0]); return nullptr; }
+        const bool is1d = ggml_n_dims(g0) == 1;
+        int64_t ne0 = g0->ne[0], acc = 0;
+        for (const char * s : srcs) { const ggml_tensor * gs = g.meta(s); if (!gs) { std::fprintf(stderr, "vla(gr00tn1d7): fused src missing %s\n", s); return nullptr; } acc += is1d ? gs->ne[0] : gs->ne[1]; }
+        ggml_tensor * t = is1d ? ggml_new_tensor_1d(W, type, acc) : ggml_new_tensor_2d(W, type, ne0, acc);
+        ggml_set_name(t, out_name);
+        FusedSpec fs{t, {}}; for (const char * s : srcs) fs.srcs.emplace_back(s); fused.push_back(std::move(fs));
+        return t;
+    };
 
     bool ok = true;
 
@@ -541,10 +639,30 @@ std::unique_ptr<ModelArchBase> gr00t_n1_7_create(const std::string& mmproj_path,
         char p[64]; auto N = [&](const char * s) { std::snprintf(p, sizeof(p), "aex.dit.%lld.%s", (long long) i, s); return p; };
         auto & w = m->dit[i];
         w.adaln_w=mk_mm(N("adaln.weight")); w.adaln_b=mk_f32(N("adaln.bias"));
-        w.Wq=mk_mm(N("attn_q.weight")); w.bq=mk_f32(N("attn_q.bias")); w.Wk=mk_mm(N("attn_k.weight")); w.bk=mk_f32(N("attn_k.bias"));
-        w.Wv=mk_mm(N("attn_v.weight")); w.bv=mk_f32(N("attn_v.bias")); w.Wo=mk_mm(N("attn_o.weight")); w.bo=mk_f32(N("attn_o.bias"));
+        if (fuse) {
+            const std::string pre = "aex.dit." + std::to_string((long long) i) + ".";
+            const std::string qn=pre+"attn_q.weight", kn=pre+"attn_k.weight", vn=pre+"attn_v.weight";
+            const std::string qb=pre+"attn_q.bias",   kb=pre+"attn_k.bias",   vb=pre+"attn_v.bias";
+            if (m->dit_interleave && (i % 2 == 1)) {
+                const std::string ow=pre+"attn_qkv.fused.w", ob=pre+"attn_qkv.fused.b";
+                w.Wqkv=mk_fused(ow.c_str(), {qn.c_str(),kn.c_str(),vn.c_str()}, m->matmul_type);
+                w.bqkv=mk_fused(ob.c_str(), {qb.c_str(),kb.c_str(),vb.c_str()}, GGML_TYPE_F32);
+                ok &= w.Wqkv&&w.bqkv;
+            } else {
+                const std::string ow=pre+"attn_kv.fused.w", ob=pre+"attn_kv.fused.b";
+                w.Wq=mk_mm(N("attn_q.weight")); w.bq=mk_f32(N("attn_q.bias"));
+                w.Wkv=mk_fused(ow.c_str(), {kn.c_str(),vn.c_str()}, m->matmul_type);
+                w.bkv=mk_fused(ob.c_str(), {kb.c_str(),vb.c_str()}, GGML_TYPE_F32);
+                ok &= w.Wq&&w.bq&&w.Wkv&&w.bkv;
+            }
+        } else {
+            w.Wq=mk_mm(N("attn_q.weight")); w.bq=mk_f32(N("attn_q.bias")); w.Wk=mk_mm(N("attn_k.weight")); w.bk=mk_f32(N("attn_k.bias"));
+            w.Wv=mk_mm(N("attn_v.weight")); w.bv=mk_f32(N("attn_v.bias"));
+            ok &= w.Wq&&w.bq&&w.Wk&&w.bk&&w.Wv&&w.bv;
+        }
+        w.Wo=mk_mm(N("attn_o.weight")); w.bo=mk_f32(N("attn_o.bias"));
         w.Wff0=mk_mm(N("ff0.weight")); w.bff0=mk_f32(N("ff0.bias")); w.Wff2=mk_mm(N("ff2.weight")); w.bff2=mk_f32(N("ff2.bias"));
-        ok &= w.adaln_w&&w.adaln_b&&w.Wq&&w.bq&&w.Wk&&w.bk&&w.Wv&&w.bv&&w.Wo&&w.bo&&w.Wff0&&w.bff0&&w.Wff2&&w.bff2;
+        ok &= w.adaln_w&&w.adaln_b&&w.Wo&&w.bo&&w.Wff0&&w.bff0&&w.Wff2&&w.bff2;
     }
     m->po1W=mk_mm("aex.dit.proj_out1.weight"); m->po1b=mk_f32("aex.dit.proj_out1.bias"); m->po2W=mk_mm("aex.dit.proj_out2.weight"); m->po2b=mk_f32("aex.dit.proj_out2.bias");
     ok &= m->vit_patch_w&&m->vit_patch_b&&m->vit_pos&&m->lm_output_norm&&m->vlln_w&&m->vlln_b&&m->se_l1W&&m->se_l1b&&m->se_l2W&&m->se_l2b&&
@@ -553,16 +671,61 @@ std::unique_ptr<ModelArchBase> gr00t_n1_7_create(const std::string& mmproj_path,
 
     m->weight_buf = ggml_backend_alloc_ctx_tensors(m->ctx_weights, m->backend);
     if (!m->weight_buf) { std::fprintf(stderr, "vla(gr00tn1d7): ggml_backend_alloc_ctx_tensors failed (OOM?)\n"); return nullptr; }
+    std::set<const ggml_tensor *> fused_dst;
+    for (const auto & fs : fused) fused_dst.insert(fs.dst);
     for (ggml_tensor * t = ggml_get_first_tensor(W); t; t = ggml_get_next_tensor(W, t)) {
+        if (fused_dst.count(t)) continue;
         std::vector<uint8_t> bytes = g.read_convert(ggml_get_name(t), t->type);
         if (bytes.empty() || bytes.size() != ggml_nbytes(t)) {
             std::fprintf(stderr, "vla(gr00tn1d7): failed to load %s (%zu vs %zu bytes)\n", ggml_get_name(t), bytes.size(), ggml_nbytes(t)); return nullptr;
         }
         ggml_backend_tensor_set(t, bytes.data(), 0, bytes.size());
     }
-    std::printf("vla(gr00tn1d7): weights resident in %.2f GiB (%s) - incl. Qwen3-VL vision tower + deepstack + vl_self_attention; embodiment id %lld\n",
+    for (const auto & fs : fused) {
+        std::vector<uint8_t> buf;
+        for (const std::string & s : fs.srcs) {
+            std::vector<uint8_t> b = g.read_convert(s.c_str(), fs.dst->type);
+            if (b.empty()) { std::fprintf(stderr, "vla(gr00tn1d7): fused fill: read %s failed\n", s.c_str()); return nullptr; }
+            buf.insert(buf.end(), b.begin(), b.end());
+        }
+        if (buf.size() != ggml_nbytes(fs.dst)) {
+            std::fprintf(stderr, "vla(gr00tn1d7): fused fill: %s size %zu vs %zu\n", ggml_get_name(fs.dst), buf.size(), ggml_nbytes(fs.dst)); return nullptr;
+        }
+        ggml_backend_tensor_set(fs.dst, buf.data(), 0, buf.size());
+    }
+    if (fuse) std::printf("vla(gr00tn1d7): QKV-fused DiT (self Wqkv / cross Wkv) — %zu fused tensors\n", fused.size());
+    std::printf("vla(gr00tn1d7): weights resident in %.2f GiB (%s) — incl. Qwen3-VL vision tower + deepstack + vl_self_attention; embodiment id %lld\n",
                 ggml_backend_buffer_get_size(m->weight_buf) / (1024.0 * 1024.0 * 1024.0), m->matmul_type == GGML_TYPE_F32 ? "F32" : "BF16", (long long) m->embodiment_id);
+    if (!m->build_caches()) { std::fprintf(stderr, "vla(gr00tn1d7): build_caches failed\n"); return nullptr; }
     return m;
+}
+
+bool Gr00tN1d7ModelArch::build_caches() {
+    if (caches_ready) return true;
+    const int64_t side = image_target_size, ps = patch_size, m2 = spatial_merge;
+    const int64_t grid = side / ps;
+    const int64_t hd_vit = vit_hidden / vit_heads;
+    const int64_t num_side = (int64_t) std::lround(std::sqrt((double) vit_num_pos));
+    const int64_t E = in_embed_dim, AH = action_horizon;
+
+    merge_block_coords(grid, grid, m2, c_grow, c_gcol);
+    vit_rope_tables(c_grow, c_gcol, hd_vit, (double) vit_rope_base, c_rope_cos, c_rope_sin);
+
+    if (!io.open(gguf_path)) { std::fprintf(stderr, "vla(gr00tn1d7): build_caches: io.open(%s) failed\n", gguf_path.c_str()); return false; }
+    std::vector<float> pos_table = io.read_f32("vit.pos_embd");
+    if (pos_table.empty() || (int64_t) pos_table.size() != vit_num_pos * vit_hidden) {
+        std::fprintf(stderr, "vla(gr00tn1d7): build_caches: vit.pos_embd unreadable\n"); return false;
+    }
+    interp_pos_embed(pos_table, num_side, vit_hidden, c_grow, c_gcol, grid, grid, c_pos_interp);
+
+    c_tau.assign((size_t) num_steps, {}); c_tproj.assign((size_t) num_steps, {});
+    for (int64_t s = 0; s < num_steps; ++s) {
+        const int64_t bucket = (int64_t) ((double) s / (double) num_steps * (double) num_buckets);
+        action_sinusoid(bucket, E, AH, c_tau[(size_t) s]);
+        timesteps_proj(bucket, c_tproj[(size_t) s]);
+    }
+    caches_ready = true;
+    return true;
 }
 
 std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
@@ -576,20 +739,12 @@ std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
     const int64_t n_patches = grid * grid;
     const int64_t K = (grid / m2) * (grid / m2);
     const int64_t hd_vit = vit_hidden / vit_heads;
-    const int64_t num_side = (int64_t) std::lround(std::sqrt((double) vit_num_pos));
     const int64_t AD = action_dim, AH = action_horizon, Nsa = 1 + AH;
+    const bool    do_dump = (std::getenv("VLA_GR00T_N17_DUMP") != nullptr);
 
-    std::vector<int64_t> grow, gcol; merge_block_coords(grid, grid, m2, grow, gcol);
-    std::vector<float> rope_cos, rope_sin; vit_rope_tables(grow, gcol, hd_vit, (double) vit_rope_base, rope_cos, rope_sin);
-
-    gguf_reader g;
-    if (!g.open(gguf_path)) return {};
-    std::vector<float> pos_interp;
-    {
-        std::vector<float> pos_table = g.read_f32("vit.pos_embd");
-        if (pos_table.empty() || (int64_t) pos_table.size() != vit_num_pos * vit_hidden) { std::fprintf(stderr, "vla(gr00tn1d7): vit.pos_embd unreadable\n"); return {}; }
-        interp_pos_embed(pos_table, num_side, vit_hidden, grow, gcol, grid, grid, pos_interp);
-    }
+    if (!caches_ready) { std::fprintf(stderr, "vla(gr00tn1d7): caches not ready\n"); return {}; }
+    const std::vector<int64_t> & grow = c_grow, & gcol = c_gcol;
+    const std::vector<float> & rope_cos = c_rope_cos, & rope_sin = c_rope_sin, & pos_interp = c_pos_interp;
 
     int64_t n_views = 0;
     std::vector<float> img_emb_host, ds_host[3];
@@ -669,7 +824,7 @@ std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
     if (SEQ > max_seq_len) { std::fprintf(stderr, "vla(gr00tn1d7): prompt too long (%lld > %lld)\n", (long long) SEQ, (long long) max_seq_len); return {}; }
 
     std::vector<float> inputs_embeds((size_t) SEQ * H);
-    if (!g.fetch_rows_f32("token_embd.weight", input_ids, inputs_embeds.data(), H)) return {};
+    if (!io.fetch_rows_f32("token_embd.weight", input_ids, inputs_embeds.data(), H)) return {};
     {   int64_t k = 0;
         for (int64_t p = 0; p < SEQ; ++p) if (input_ids[p] == (int32_t) image_token_index) {
             if (k >= n_img) { std::fprintf(stderr, "vla(gr00tn1d7): more <image> tokens than ViT embeds\n"); return {}; }
@@ -702,6 +857,14 @@ std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
     if (in.noise) std::memcpy(x_init.data(), in.noise, x_init.size() * sizeof(float));
     else { std::mt19937 rng((uint32_t) std::chrono::steady_clock::now().time_since_epoch().count()); std::normal_distribution<float> nd(0.f, 1.f); for (auto & v : x_init) v = nd(rng); }
 
+    const bool use_cache = (std::getenv("VLA_GR00T_GRAPH_CACHE") != nullptr) && !do_dump;
+    const bool reuse = use_cache && mg.valid && mg.seq == SEQ && mg.n_img == n_img &&
+                       mg.seq_txt == SEQ_TXT && mg.nsteps == num_steps && mg.deepstack == inject_deepstack;
+
+    ggml_tensor * eagle = nullptr, * vl_embs = nullptr;
+    std::vector<ggml_tensor*> lm_h_dump, vlsa_dump;
+    if (!reuse) {
+    if (mg.C) mg.release();
     ggml_init_params cp = { (size_t) 256 * 1024 * 1024, nullptr, true };
     ggml_context * C = ggml_init(cp);
     if (!C) { std::fprintf(stderr, "vla(gr00tn1d7): ggml_init(ctx_compute) failed\n"); return {}; }
@@ -725,22 +888,20 @@ std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
     }
 
     ggml_tensor * h = t_embeds;
-    std::vector<ggml_tensor*> lm_h_dump;
     for (int64_t i = 0; i < lm_layers; ++i) {
         h = build_qwen3_layer(C, *this, lm[i], h, t_pos, t_lmmask, SEQ);
         if (inject_deepstack && i < 3) h = ggml_add(C, h, t_ds[i]);
-        if (std::getenv("VLA_GR00T_N17_DUMP")) { ggml_set_output(h); lm_h_dump.push_back(h); }
+        if (do_dump) { ggml_set_output(h); lm_h_dump.push_back(h); }
     }
 
-    ggml_tensor * eagle = h;
+    eagle = h;
     ggml_set_name(eagle, "eagle"); ggml_set_output(eagle);
 
-    ggml_tensor * vl_embs = ggml_add(C, ggml_mul(C, ggml_norm(C, eagle, vlln_eps), vlln_w), vlln_b);
-    std::vector<ggml_tensor*> vlsa_dump;
-    if (std::getenv("VLA_GR00T_N17_DUMP")) { ggml_set_output(vl_embs); vlsa_dump.push_back(vl_embs); }
+    vl_embs = ggml_add(C, ggml_mul(C, ggml_norm(C, eagle, vlln_eps), vlln_w), vlln_b);
+    if (do_dump) { ggml_set_output(vl_embs); vlsa_dump.push_back(vl_embs); }
     for (int64_t i = 0; i < vlsa_layers; ++i) {
         vl_embs = build_vlsa_layer(C, vlsa[i], vl_embs, SEQ, vlsa_heads, vlsa_head_dim, bb_embed_dim, vlsa_ln_eps);
-        if (std::getenv("VLA_GR00T_N17_DUMP")) { ggml_set_output(vl_embs); vlsa_dump.push_back(vl_embs); }
+        if (do_dump) { ggml_set_output(vl_embs); vlsa_dump.push_back(vl_embs); }
     }
     ggml_set_name(vl_embs, "vl_embs"); ggml_set_output(vl_embs);
 
@@ -751,6 +912,14 @@ std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
 
     const float dt = 1.0f / (float) num_steps;
     const int64_t every2 = 2 * attend_text_every_n;
+
+    std::vector<ggml_tensor *> Kc(dit_layers, nullptr), Vc(dit_layers, nullptr);
+    for (int64_t i = 0; i < dit_layers; ++i) {
+        if (dit_interleave && (i % 2 == 1)) continue;
+        ggml_tensor * enc = (i % every2 == 0) ? vl_txt : vl_img;
+        dit_kv(C, *this, dit[i], enc, &Kc[i], &Vc[i]);
+    }
+
     ggml_tensor * actions = t_x0;
     for (int64_t s = 0; s < num_steps; ++s) {
         ggml_tensor * temb = ggml_add(C, ggml_mul_mat(C, te_l2W, ggml_silu(C, ggml_add(C, ggml_mul_mat(C, te_l1W, t_tproj[s]), te_l1b))), te_l2b);
@@ -764,7 +933,7 @@ std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
             if (dit_interleave && (i % 2 == 1)) enc = nullptr;
             else if (i % every2 == 0)           enc = vl_txt;
             else                                enc = vl_img;
-            hh = build_dit_block(C, *this, dit[i], hh, temb, enc);
+            hh = build_dit_block(C, *this, dit[i], hh, temb, enc, Kc[i], Vc[i]);
         }
         ggml_tensor * po = ggml_add(C, ggml_mul_mat(C, po1W, ggml_silu(C, temb)), po1b);
         ggml_tensor * sh = ggml_view_1d(C, po, dit_hidden, 0), * sc = ggml_view_1d(C, po, dit_hidden, (size_t) dit_hidden * sizeof(float));
@@ -782,6 +951,20 @@ std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
 
     ggml_gallocr_t galloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
     if (!galloc || !ggml_gallocr_alloc_graph(galloc, gf)) { std::fprintf(stderr, "vla(gr00tn1d7): gallocr alloc failed\n"); if (galloc) ggml_gallocr_free(galloc); ggml_free(C); return {}; }
+
+        mg.C=C; mg.galloc=galloc; mg.gf=gf;
+        mg.t_embeds=t_embeds; mg.t_pos=t_pos; mg.t_lmmask=t_lmmask; mg.t_state=t_state; mg.t_x0=t_x0;
+        mg.t_ds[0]=t_ds[0]; mg.t_ds[1]=t_ds[1]; mg.t_ds[2]=t_ds[2];
+        mg.t_img_idx=t_img_idx; mg.t_txt_idx=t_txt_idx; mg.t_tau=t_tau; mg.t_tproj=t_tproj; mg.actions=actions;
+        mg.seq=SEQ; mg.n_img=n_img; mg.seq_txt=SEQ_TXT; mg.nsteps=num_steps; mg.deepstack=inject_deepstack;
+        mg.valid = use_cache;
+    }
+
+    ggml_context * C = mg.C; ggml_cgraph * gf = mg.gf; ggml_gallocr_t galloc = mg.galloc; (void) C; (void) galloc;
+    ggml_tensor * t_embeds = mg.t_embeds, * t_pos = mg.t_pos, * t_lmmask = mg.t_lmmask, * t_state = mg.t_state, * t_x0 = mg.t_x0;
+    ggml_tensor * t_ds[3] = { mg.t_ds[0], mg.t_ds[1], mg.t_ds[2] };
+    ggml_tensor * t_img_idx = mg.t_img_idx, * t_txt_idx = mg.t_txt_idx, * actions = mg.actions;
+    std::vector<ggml_tensor*> & t_tau = mg.t_tau; std::vector<ggml_tensor*> & t_tproj = mg.t_tproj;
 
     ggml_backend_tensor_set(t_embeds, inputs_embeds.data(), 0, ggml_nbytes(t_embeds));
     {
@@ -809,7 +992,7 @@ std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
             if (n_img_tokens % (llm_grid_h * llm_grid_w) != 0) {
                 std::fprintf(stderr, "vla(gr00tn1d7): image run length %lld not a multiple of %lld (post-merge grid)\n",
                              (long long) n_img_tokens, (long long) (llm_grid_h * llm_grid_w));
-                ggml_gallocr_free(galloc); ggml_free(C); return {};
+                mg.release(); return {};
             }
             const int64_t this_t = n_img_tokens / (llm_grid_h * llm_grid_w);
             const int64_t image_offset = text_len + st_idx;
@@ -834,25 +1017,26 @@ std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
         std::memcpy(pp.data() + (size_t) 3 * SEQ, pp.data() + (size_t) 0 * SEQ, (size_t) SEQ * sizeof(int32_t));
         ggml_backend_tensor_set(t_pos, pp.data(), 0, ggml_nbytes(t_pos));
     }
-    { std::vector<float> mk((size_t) SEQ * SEQ); const float NEG = -std::numeric_limits<float>::infinity();
-      for (int64_t q = 0; q < SEQ; ++q) for (int64_t kv = 0; kv < SEQ; ++kv) mk[q * SEQ + kv] = (kv <= q) ? 0.0f : NEG;
-      ggml_backend_tensor_set(t_lmmask, mk.data(), 0, ggml_nbytes(t_lmmask)); }
+    if (c_mask_seq != SEQ) {
+        c_mask.assign((size_t) SEQ * SEQ, 0.0f); const float NEG = -std::numeric_limits<float>::infinity();
+        for (int64_t q = 0; q < SEQ; ++q) for (int64_t kv = 0; kv < SEQ; ++kv) c_mask[q * SEQ + kv] = (kv <= q) ? 0.0f : NEG;
+        c_mask_seq = SEQ;
+    }
+    ggml_backend_tensor_set(t_lmmask, c_mask.data(), 0, ggml_nbytes(t_lmmask));
     { std::vector<float> st(max_state_dim, 0.0f); for (int64_t i = 0; i < max_state_dim; ++i) st[i] = in.state ? in.state[i] : 0.0f; ggml_backend_tensor_set(t_state, st.data(), 0, ggml_nbytes(t_state)); }
     ggml_backend_tensor_set(t_x0, x_init.data(), 0, ggml_nbytes(t_x0));
     if (inject_deepstack) for (int j = 0; j < 3; ++j) ggml_backend_tensor_set(t_ds[j], ds_pad[j].data(), 0, ggml_nbytes(t_ds[j]));
     ggml_backend_tensor_set(t_img_idx, image_pos_idx.data(), 0, ggml_nbytes(t_img_idx));
     if (t_txt_idx) ggml_backend_tensor_set(t_txt_idx, text_pos_idx.data(), 0, ggml_nbytes(t_txt_idx));
     for (int64_t s = 0; s < num_steps; ++s) {
-        const int64_t bucket = (int64_t) ((double) s / (double) num_steps * (double) num_buckets);
-        std::vector<float> tau, tpr; action_sinusoid(bucket, E, AH, tau); timesteps_proj(bucket, tpr);
-        ggml_backend_tensor_set(t_tau[s],   tau.data(), 0, ggml_nbytes(t_tau[s]));
-        ggml_backend_tensor_set(t_tproj[s], tpr.data(), 0, ggml_nbytes(t_tproj[s]));
+        ggml_backend_tensor_set(t_tau[s],   c_tau[(size_t) s].data(),   0, ggml_nbytes(t_tau[s]));
+        ggml_backend_tensor_set(t_tproj[s], c_tproj[(size_t) s].data(), 0, ggml_nbytes(t_tproj[s]));
     }
 
     const auto tc0 = std::chrono::steady_clock::now();
     const ggml_status st = ggml_backend_graph_compute(backend, gf);
     const auto tc1 = std::chrono::steady_clock::now();
-    if (st != GGML_STATUS_SUCCESS) { std::fprintf(stderr, "vla(gr00tn1d7): graph compute failed (%d)\n", (int) st); ggml_gallocr_free(galloc); ggml_free(C); return {}; }
+    if (st != GGML_STATUS_SUCCESS) { std::fprintf(stderr, "vla(gr00tn1d7): graph compute failed (%d)\n", (int) st); mg.release(); return {}; }
     stats.ms_inference = std::chrono::duration<float, std::milli>(tc1 - tc0).count();
 
     std::vector<float> out((size_t) AH * AD);
@@ -893,7 +1077,7 @@ std::vector<float> Gr00tN1d7ModelArch::predict(const Inputs& in) {
             }
         }
     }
-    ggml_gallocr_free(galloc); ggml_free(C);
+    if (!use_cache) mg.release();
     stats.ms_total = std::chrono::duration<float, std::milli>(std::chrono::steady_clock::now() - t0).count();
     return out;
 }


### PR DESCRIPTION
- Cut GR00T-N1.7 latency from 119 to 101.7 ms/step (RTX 5070) with an cross-attn K/V cache and self-attn QKV fusion (both bit-exact), plus opt-in graph cache and flash-attention.
- Update llama.cpp: Add a reusable ggml CUDA flash-attention head_dim=48 patch.