### PR TITLE
Support Metal backend for Apple Silicon hardware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,10 @@ if(GGML_CUDA)
     target_include_directories(vla_core PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
 endif()
 
+if(GGML_METAL AND NOT GGML_CUDA)
+    target_compile_definitions(vla_core PUBLIC GGML_USE_METAL)
+endif()
+
 add_library(vlm_core
     src/vlm/engine.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ target_include_directories(vla-server PRIVATE
 )
 target_link_libraries(vla-server PRIVATE
     vla_core
-    ${Protobuf_LIBRARIES}
+    protobuf::libprotobuf
     PkgConfig::ZeroMQ
 )
 
@@ -134,6 +134,6 @@ target_include_directories(vlm-server PRIVATE
 )
 target_link_libraries(vlm-server PRIVATE
     vlm_core
-    ${Protobuf_LIBRARIES}
+    protobuf::libprotobuf
     PkgConfig::ZeroMQ
 )

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 An efficient C++ inference engine for **Vision-Language-Action (VLA) models**, built on top of [`llama.cpp`](https://github.com/ggml-org/llama.cpp).
 It brings today's open VLA policies - SmolVLA, π0, BitVLA, Evo-1, and GR00T N1.5/1.6/1.7 - under one runtime, packaging each as a single self-contained GGUF that needs no Python or PyTorch at inference time.
-The binary can drive robots across CPU or CUDA, scaling from consumer GPUs down to the Jetson-class boards.
+The binary can drive robots across **CPU**, **Apple Silicon**, or **CUDA**, scaling from consumer GPUs down to the Jetson-class boards.
 
 ## Build the server
 
@@ -61,6 +61,8 @@ If system cannot detect CUDA, declare CUDA explicitly in environment variables
 export PATH=/usr/local/cuda/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 ```
+
+On Apple Silicon (e.g. Mac Mini M4), Metal is enabled by default and runs both the transformer and vision tower on the GPU. See [docs/backend/metal.md](docs/backend/metal.md) for building `vla.cpp` on macOS.
 
 ## Install simulators
 

--- a/docs/backend/metal.md
+++ b/docs/backend/metal.md
@@ -1,0 +1,31 @@
+# `vla.cpp` on macOS (Metal backend)
+
+Short notes for getting `vla.cpp` to compile and link on macOS. The Metal
+backend is auto-detected by the vendored `llama.cpp`/`ggml` and needs no special
+CMake flag.
+
+> **Status:** macOS/Metal is **build-and-link validated only**. All VLA inference
+> paths in this repo (parity tests, LIBERO/SIMPLER sweeps, latency numbers) are
+> CUDA-validated — see `CLAUDE.md`/`NOTES.md`. Treat Metal as a way to compile
+> and develop on a Mac, not as a benchmarked inference target.
+
+## Prerequisites
+
+```bash
+brew install protobuf zeromq cppzmq pkg-config
+```
+## Configure & build
+
+On MacOS, Metal is enabled by default. Using Metal makes the computation run on the GPU.
+To disable the Metal build at compile time use the `-DGGML_METAL=OFF` cmake option.
+
+When built with Metal support, you can explicitly disable GPU inference with the `--n-gpu-layers 0` command-line argument.
+
+```bash
+# Fetch llama.cpp at pinned tag and apply local patch
+bash patches/patch.sh
+
+# On MacOS, Metal is enabled by default
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(sysctl -n hw.ncpu)
+```

--- a/docs/backend/metal.md
+++ b/docs/backend/metal.md
@@ -63,4 +63,5 @@ then it settles to ~321–328 ms/req.
 | Model       | SR  | Client/step | Server/step                          |
 |-------------|----:|------------:|--------------------------------------|
 | SmolVLA     | 0.7 |     888 ms  | 324 ms (181 vision + 141 inf + 2)    |
+| Pi0         | 0.8 |    1135 ms  | 1129 ms (922 vision + 200 inf + 7)   |
 | Gr00t-n1.7  | 1.0 |     755 ms  | 600 ms (185 vision + 405 inf + 10)   |

--- a/docs/backend/metal.md
+++ b/docs/backend/metal.md
@@ -56,4 +56,11 @@ SmolVLA (libero, `mmproj` + 878 MiB BF16 weights), **Apple M4**, steady state:
 | **total/req**|  ~35,250 ms  |         **~324 ms** |
 
 ≈ **108× faster** end-to-end. First request is ~671 ms (Metal pipeline warmup),
-then it settles to ~321–328 ms/req. Raw server log:
+then it settles to ~321–328 ms/req.
+
+### libero_object (10 episodes, Apple M4)
+
+| Model       | SR  | Client/step | Server/step                          |
+|-------------|----:|------------:|--------------------------------------|
+| SmolVLA     | 0.7 |     888 ms  | 324 ms (181 vision + 141 inf + 2)    |
+| Gr00t-n1.7  | 1.0 |     755 ms  | 600 ms (185 vision + 405 inf + 10)   |

--- a/docs/backend/metal.md
+++ b/docs/backend/metal.md
@@ -4,11 +4,6 @@ Short notes for getting `vla.cpp` to compile and link on macOS. The Metal
 backend is auto-detected by the vendored `llama.cpp`/`ggml` and needs no special
 CMake flag.
 
-> **Status:** macOS/Metal is **build-and-link validated only**. All VLA inference
-> paths in this repo (parity tests, LIBERO/SIMPLER sweeps, latency numbers) are
-> CUDA-validated — see `CLAUDE.md`/`NOTES.md`. Treat Metal as a way to compile
-> and develop on a Mac, not as a benchmarked inference target.
-
 ## Prerequisites
 
 ```bash
@@ -29,3 +24,36 @@ bash patches/patch.sh
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j$(sysctl -n hw.ncpu)
 ```
+
+## GPU offload
+
+The VLA core selects its compute backend at load time. On macOS it picks Metal
+(`ggml_backend_metal_init`); the CLIP/vision encoder mirrors that choice, so both
+the transformer and the vision tower run on the GPU. Confirm it from the startup
+banner:
+
+```
+vla: backend = Metal
+clip_ctx: CLIP using GPU backend
+```
+
+If you instead see `vla: backend = CPU (4 threads)` / `CLIP using CPU backend`,
+the build didn't pick up Metal — rebuild from a clean `build/` and check
+`GGML_METAL` is `ON` in the CMake cache.
+
+> Single-backend, no per-op CPU fallback: the core uses one backend + `gallocr`,
+> not a scheduler. SmolVLA's ops are all Metal-supported; an arch that hits an
+> unimplemented op would assert at predict time rather than silently fall back.
+
+## Results
+
+SmolVLA (libero, `mmproj` + 878 MiB BF16 weights), **Apple M4**, steady state:
+
+| Stage        | CPU (before) | Metal GPU (after) |
+|--------------|-------------:|------------------:|
+| vision       |   22,367 ms  |          ~178 ms  |
+| inference    |   12,878 ms  |          ~144 ms  |
+| **total/req**|  ~35,250 ms  |         **~324 ms** |
+
+≈ **108× faster** end-to-end. First request is ~671 ms (Metal pipeline warmup),
+then it settles to ~321–328 ms/req. Raw server log:

--- a/src/models/evo1.cpp
+++ b/src/models/evo1.cpp
@@ -21,6 +21,9 @@
 #ifdef GGML_USE_CUDA
 #include "ggml-cuda.h"
 #endif
+#ifdef GGML_USE_METAL
+#include "ggml-metal.h"
+#endif
 #include "gguf.h"
 
 #include <chrono>
@@ -156,6 +159,7 @@ struct Evo1ModelArch : public ModelArchBase {
     std::string           gguf_path;
     ggml_backend_t        backend     = nullptr;
     bool                  is_cuda     = false;
+    bool                  is_gpu      = false;
     int                   n_threads   = 4;
     ggml_context *        ctx_weights = nullptr;
     ggml_backend_buffer_t weight_buf  = nullptr;
@@ -378,8 +382,12 @@ std::unique_ptr<ModelArchBase> evo1_create(const std::string& mmproj_path,
 
 #ifdef GGML_USE_CUDA
     m->backend = ggml_backend_cuda_init(0);
-    if (m->backend) { m->is_cuda = true; std::printf("vla(evo1): backend = CUDA (device 0)\n"); }
+    if (m->backend) { m->is_cuda = true; m->is_gpu = true; std::printf("vla(evo1): backend = CUDA (device 0)\n"); }
     else            std::fprintf(stderr, "vla(evo1): ggml_backend_cuda_init failed; falling back to CPU\n");
+#elif defined(GGML_USE_METAL)
+    m->backend = ggml_backend_metal_init();
+    if (m->backend) { m->is_gpu = true; std::printf("vla(evo1): backend = Metal\n"); }
+    else            std::fprintf(stderr, "vla(evo1): ggml_backend_metal_init failed; falling back to CPU\n");
 #endif
     if (!m->backend) {
         m->backend = ggml_backend_cpu_init();

--- a/src/models/gr00tn1d5.cpp
+++ b/src/models/gr00tn1d5.cpp
@@ -21,6 +21,9 @@
 #ifdef GGML_USE_CUDA
 #include "ggml-cuda.h"
 #endif
+#ifdef GGML_USE_METAL
+#include "ggml-metal.h"
+#endif
 #include "gguf.h"
 
 #include <chrono>
@@ -133,6 +136,7 @@ struct Gr00tN1d5ModelArch : public ModelArchBase {
     std::string           gguf_path;
     ggml_backend_t        backend     = nullptr;
     bool                  is_cuda     = false;
+    bool                  is_gpu      = false;
     int                   n_threads   = 4;
     ggml_context *        ctx_weights = nullptr;
     ggml_backend_buffer_t weight_buf  = nullptr;
@@ -373,8 +377,12 @@ std::unique_ptr<ModelArchBase> gr00t_n1_5_create(const std::string& mmproj_path,
 
 #ifdef GGML_USE_CUDA
     m->backend = ggml_backend_cuda_init(0);
-    if (m->backend) { m->is_cuda = true; std::printf("vla(gr00tn1d5): backend = CUDA (device 0)\n"); }
+    if (m->backend) { m->is_cuda = true; m->is_gpu = true; std::printf("vla(gr00tn1d5): backend = CUDA (device 0)\n"); }
     else            std::fprintf(stderr, "vla(gr00tn1d5): ggml_backend_cuda_init failed; falling back to CPU\n");
+#elif defined(GGML_USE_METAL)
+    m->backend = ggml_backend_metal_init();
+    if (m->backend) { m->is_gpu = true; std::printf("vla(gr00tn1d5): backend = Metal\n"); }
+    else            std::fprintf(stderr, "vla(gr00tn1d5): ggml_backend_metal_init failed; falling back to CPU\n");
 #endif
     if (!m->backend) {
         m->backend = ggml_backend_cpu_init();

--- a/src/models/gr00tn1d6.cpp
+++ b/src/models/gr00tn1d6.cpp
@@ -21,6 +21,9 @@
 #ifdef GGML_USE_CUDA
 #include "ggml-cuda.h"
 #endif
+#ifdef GGML_USE_METAL
+#include "ggml-metal.h"
+#endif
 #include "gguf.h"
 
 #include <chrono>
@@ -132,6 +135,7 @@ struct Gr00tN1d6ModelArch : public ModelArchBase {
     std::string           gguf_path;
     ggml_backend_t        backend     = nullptr;
     bool                  is_cuda     = false;
+    bool                  is_gpu      = false;
     int                   n_threads   = 4;
     ggml_context *        ctx_weights = nullptr;
     ggml_backend_buffer_t weight_buf  = nullptr;
@@ -378,8 +382,12 @@ std::unique_ptr<ModelArchBase> gr00t_n1_6_create(const std::string& mmproj_path,
 
 #ifdef GGML_USE_CUDA
     m->backend = ggml_backend_cuda_init(0);
-    if (m->backend) { m->is_cuda = true; std::printf("vla(gr00tn1d6): backend = CUDA (device 0)\n"); }
+    if (m->backend) { m->is_cuda = true; m->is_gpu = true; std::printf("vla(gr00tn1d6): backend = CUDA (device 0)\n"); }
     else            std::fprintf(stderr, "vla(gr00tn1d6): ggml_backend_cuda_init failed; falling back to CPU\n");
+#elif defined(GGML_USE_METAL)
+    m->backend = ggml_backend_metal_init();
+    if (m->backend) { m->is_gpu = true; std::printf("vla(gr00tn1d6): backend = Metal\n"); }
+    else            std::fprintf(stderr, "vla(gr00tn1d6): ggml_backend_metal_init failed; falling back to CPU\n");
 #endif
     if (!m->backend) {
         m->backend = ggml_backend_cpu_init();

--- a/src/models/gr00tn1d7.cpp
+++ b/src/models/gr00tn1d7.cpp
@@ -21,6 +21,9 @@
 #ifdef GGML_USE_CUDA
 #include "ggml-cuda.h"
 #endif
+#ifdef GGML_USE_METAL
+#include "ggml-metal.h"
+#endif
 #include "gguf.h"
 
 #include <chrono>
@@ -139,6 +142,7 @@ struct Gr00tN1d7ModelArch : public ModelArchBase {
     std::string           gguf_path;
     ggml_backend_t        backend     = nullptr;
     bool                  is_cuda     = false;
+    bool                  is_gpu      = false;
     int                   n_threads   = 4;
     ggml_context *        ctx_weights = nullptr;
     ggml_backend_buffer_t weight_buf  = nullptr;
@@ -546,8 +550,12 @@ std::unique_ptr<ModelArchBase> gr00t_n1_7_create(const std::string& mmproj_path,
 
 #ifdef GGML_USE_CUDA
     m->backend = ggml_backend_cuda_init(0);
-    if (m->backend) { m->is_cuda = true; std::printf("vla(gr00tn1d7): backend = CUDA (device 0)\n"); }
+    if (m->backend) { m->is_cuda = true; m->is_gpu = true; std::printf("vla(gr00tn1d7): backend = CUDA (device 0)\n"); }
     else            std::fprintf(stderr, "vla(gr00tn1d7): ggml_backend_cuda_init failed; falling back to CPU\n");
+#elif defined(GGML_USE_METAL)
+    m->backend = ggml_backend_metal_init();
+    if (m->backend) { m->is_gpu = true; std::printf("vla(gr00tn1d7): backend = Metal\n"); }
+    else            std::fprintf(stderr, "vla(gr00tn1d7): ggml_backend_metal_init failed; falling back to CPU\n");
 #endif
     if (!m->backend) {
         m->backend = ggml_backend_cpu_init();

--- a/src/models/pi0.cpp
+++ b/src/models/pi0.cpp
@@ -24,6 +24,9 @@
 #ifdef GGML_USE_CUDA
 #include "ggml-cuda.h"
 #endif
+#ifdef GGML_USE_METAL
+#include "ggml-metal.h"
+#endif
 #include "gguf.h"
 
 #include <algorithm>
@@ -194,6 +197,7 @@ struct Pi0ModelArch : public ModelArchBase {
     clip_ctx *            cctx        = nullptr;
     ggml_backend_t        backend     = nullptr;
     bool                  is_cuda     = false;
+    bool                  is_gpu      = false;
     ggml_backend_buffer_t weight_buf  = nullptr;
     ggml_context *        ctx_weights = nullptr;
     std::string           ckpt_path_;
@@ -404,8 +408,12 @@ std::unique_ptr<ModelArchBase> pi0_create(const std::string& mmproj_path,
 
 #ifdef GGML_USE_CUDA
     m->backend = ggml_backend_cuda_init( 0);
-    if (m->backend) { m->is_cuda = true; std::printf("vla(pi0): backend = CUDA (device 0)\n"); }
+    if (m->backend) { m->is_cuda = true; m->is_gpu = true; std::printf("vla(pi0): backend = CUDA (device 0)\n"); }
     else            { std::fprintf(stderr, "vla(pi0): ggml_backend_cuda_init failed; falling back to CPU\n"); }
+#elif defined(GGML_USE_METAL)
+    m->backend = ggml_backend_metal_init();
+    if (m->backend) { m->is_gpu = true; std::printf("vla(pi0): backend = Metal\n"); }
+    else            { std::fprintf(stderr, "vla(pi0): ggml_backend_metal_init failed; falling back to CPU\n"); }
 #endif
     {
         const unsigned hw = std::thread::hardware_concurrency();
@@ -420,11 +428,11 @@ std::unique_ptr<ModelArchBase> pi0_create(const std::string& mmproj_path,
 
     {
         clip_context_params cp = {};
-        cp.use_gpu           = m->is_cuda;
-        cp.flash_attn_type   = m->is_cuda ? CLIP_FLASH_ATTN_TYPE_AUTO : CLIP_FLASH_ATTN_TYPE_DISABLED;
+        cp.use_gpu           = m->is_gpu;
+        cp.flash_attn_type   = m->is_gpu ? CLIP_FLASH_ATTN_TYPE_AUTO : CLIP_FLASH_ATTN_TYPE_DISABLED;
         cp.image_min_tokens  = -1;
         cp.image_max_tokens  = -1;
-        cp.warmup            = m->is_cuda;
+        cp.warmup            = m->is_gpu;
         cp.cb_eval           = nullptr;
         cp.cb_eval_user_data = nullptr;
         clip_init_result r = clip_init(mmproj_path.c_str(), cp);

--- a/src/models/smolvla.cpp
+++ b/src/models/smolvla.cpp
@@ -27,6 +27,9 @@
 #ifdef GGML_USE_CUDA
 #include "ggml-cuda.h"
 #endif
+#ifdef GGML_USE_METAL
+#include "ggml-metal.h"
+#endif
 
 #include "nlohmann/json.hpp"
 
@@ -280,6 +283,7 @@ struct SmolVLAModelArch : public ModelArchBase {
     ggml_backend_t        backend     = nullptr;
     ggml_backend_buffer_t weight_buf  = nullptr;
     bool                  is_cuda     = false;
+    bool                  is_gpu      = false;
 
     ggml_type             weight_dtype = GGML_TYPE_BF16;
 
@@ -836,9 +840,18 @@ SmolVLAModelArch* smolvla_load_impl(const std::string& mmproj_path,
     m->backend = ggml_backend_cuda_init( 0);
     if (m->backend) {
         m->is_cuda = true;
+        m->is_gpu  = true;
         std::printf("vla: backend = CUDA (device 0)\n");
     } else {
         std::fprintf(stderr, "vla: ggml_backend_cuda_init failed; falling back to CPU\n");
+    }
+#elif defined(GGML_USE_METAL)
+    m->backend = ggml_backend_metal_init();
+    if (m->backend) {
+        m->is_gpu = true;
+        std::printf("vla: backend = Metal\n");
+    } else {
+        std::fprintf(stderr, "vla: ggml_backend_metal_init failed; falling back to CPU\n");
     }
 #endif
     if (!m->backend) {
@@ -857,7 +870,7 @@ SmolVLAModelArch* smolvla_load_impl(const std::string& mmproj_path,
     std::printf("vla: tower weights resident as %s\n", ggml_type_name(m->weight_dtype));
 
     clip_context_params cparams = {};
-    cparams.use_gpu          = m->is_cuda;
+    cparams.use_gpu          = m->is_gpu;
 
     cparams.flash_attn_type  = CLIP_FLASH_ATTN_TYPE_AUTO;
     cparams.image_min_tokens = -1;


### PR DESCRIPTION
Support Metal backend via `GGML_USE_METAL` build flag. When it is enabled, init the backend by `ggml_backend_metal_init();`
This feature is applied for all models except BitVLA because BitVLA is mainly running on CUDA backend with custom bit kernel, which has been not yet implemented in Metal so far.